### PR TITLE
V2-3010 add slider proptype

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ let props = {
   optionalCategory: ElementPropTypes.category,
   optionalCategory: ElementPropTypes.sectionHeader,
   optionalImage: ElementPropTypes.image,
+  optionalSlider: ElementPropTypes.slider,
   optionalMedia: ElementPropTypes.media,
   optionalEditorFull: ElementPropTypes.editorFull,
   optionalEditorMinimal: ElementPropTypes.editorMinimal,
@@ -45,6 +46,7 @@ let props = {
   requiredCategory: ElementPropTypes.category,
   requiredCategory: ElementPropTypes.sectionHeader,
   requiredImage: ElementPropTypes.image,
+  requiredSlider: ElementPropTypes.slider,
   requiredMedia: ElementPropTypes.media,
   requiredEditorFull: ElementPropTypes.editorFull,
   requiredEditorMinimal: ElementPropTypes.editorMinimal,
@@ -289,6 +291,47 @@ const meta = extractMetadata(props);
     },
     isRequired: true
   },
+  'Optional Slider': {
+    objMeta: {
+        Min: {
+            propName: 'uriBase',
+            type: 'string'
+        },
+        Max: {
+            propName: 'imagePath',
+            type: 'string'
+        },
+        'Step Size': {
+            propName: 'altText',
+            type: 'string'
+        },
+        'Selected Value': {
+            propName: 'width',
+            type: 'number'
+        }
+    }
+  },
+  'Required Slider': {
+    objMeta: {
+        Min: {
+            propName: 'uriBase',
+            type: 'string'
+        },
+        Max: {
+            propName: 'imagePath',
+            type: 'string'
+        },
+        'Step Size': {
+            propName: 'altText',
+            type: 'string'
+        },
+        'Selected Value': {
+            propName: 'width',
+            type: 'number'
+        }
+    },
+    isRequired: true
+  },
   'Embeddable': {
     objMeta: {
      'Embed Type': {
@@ -426,6 +469,39 @@ And it would be used in default props like this:
 ```
 defaultProps = {
     imageConfig: ElementPropTypes.image.default
+}
+```
+
+### Using the slider proptype
+
+The `slider` propType will display an horizontal slider for picking a numeric value in Site Designer when editing the block config.
+
+Site Designer will populate the `slider` like this when a value has been selected:
+
+```
+sliderConfig: {
+    min: 50,
+    max: 100,
+    stepSize: 5,
+    selectedValue: 75
+}
+```
+
+You can use `ElementPropTypes.slider.default` in your default props, which will return this:
+
+```
+{
+    min: 0,
+    max: 10,
+    stepSize: 1,
+    selectedValue: 0
+}
+```
+
+And it would be used in default props like this:
+```
+defaultProps = {
+    sliderConfig: ElementPropTypes.slider.default
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -294,19 +294,19 @@ const meta = extractMetadata(props);
   'Optional Slider': {
     objMeta: {
         Min: {
-            propName: 'uriBase',
-            type: 'string'
+            propName: 'min',
+            type: 'number'
         },
         Max: {
-            propName: 'imagePath',
-            type: 'string'
+            propName: 'max',
+            type: 'number'
         },
         'Step Size': {
-            propName: 'altText',
-            type: 'string'
+            propName: 'stepSize',
+            type: 'number'
         },
         'Selected Value': {
-            propName: 'width',
+            propName: 'selectedValue',
             type: 'number'
         }
     }
@@ -314,19 +314,19 @@ const meta = extractMetadata(props);
   'Required Slider': {
     objMeta: {
         Min: {
-            propName: 'uriBase',
-            type: 'string'
+            propName: 'min',
+            type: 'number'
         },
         Max: {
-            propName: 'imagePath',
-            type: 'string'
+            propName: 'max',
+            type: 'number'
         },
         'Step Size': {
-            propName: 'altText',
-            type: 'string'
+            propName: 'stepSize',
+            type: 'number'
         },
         'Selected Value': {
-            propName: 'width',
+            propName: 'selectedValue',
             type: 'number'
         }
     },

--- a/src/__tests__/extractMeta.js
+++ b/src/__tests__/extractMeta.js
@@ -390,6 +390,38 @@ describe('Metadata extractor', () => {
         });
     });
 
+    it('Extracts metadata from slider type', () => {
+        const props = {
+            sliderProp: ElementPropTypes.slider,
+            sliderPropRequired: ElementPropTypes.slider.isRequired
+        };
+
+        const extracted = extractMetadata(props);
+
+        expect(extracted['Slider Prop']).toEqual({
+            propName: 'sliderProp',
+            type: 'slider'
+        });
+
+        expect(extracted['Slider Prop Required']).toEqual({
+            propName: 'sliderPropRequired',
+            type: 'slider',
+            isRequired: true
+        });
+    });
+
+    it('Returns a default config for the slider type', () => {
+        const props = {
+            sliderProp: ElementPropTypes.slider
+        };
+        expect(props.sliderProp.default).toEqual({
+            min: 0,
+            max: 10,
+            stepSize: 1,
+            selectedValue: 0
+        });
+    });
+
     it('Extracts metadata from readOnly type', () => {
         const props = {
             aReadOnly: ElementPropTypes.readOnly

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -16,6 +16,7 @@ function getShim() {
     'color',
     'number',
     'image',
+    'slider',
     'media',
     'product',
     'category',
@@ -38,6 +39,12 @@ const defaults = {
         altText: '',
         width: 0,
         height: 0
+    },
+    slider: {
+        min: 0,
+        max: 10,
+        stepSize: 1,
+        selectedValue: 0
     }
 };
 
@@ -112,6 +119,7 @@ const ElementPropTypes = {
     category: primitiveProp('category'),
     sectionHeader: primitiveProp('sectionHeader'),
     image: primitiveProp('image'),
+    slider: primitiveProp('slider'),
     arrayOf: createTypeOfTypeChecker('arrayOf'),
     objectOf: createTypeOfTypeChecker('objectOf'),
     embeddable: createShapeTypeChecker('embeddable'),


### PR DESCRIPTION
These changes add support for a `slider` proptype with default values. The intended support in Site Designer will be a horizontal slider component for selecting a single numeric value with a defined range and step.