### PR TITLE
[V2-3027] name changes should not be breaking change

### DIFF
--- a/src/__tests__/extractMeta.js
+++ b/src/__tests__/extractMeta.js
@@ -439,11 +439,11 @@ describe('Metadata extractor', () => {
         const props = {
             devName: {
                 type: ElementPropTypes.string,
-                uiLabel: 'Ui label'
+                label: 'Ui label'
             },
             devNameTwo: {
                 type: ElementPropTypes.string,
-                uiLabel: 'Ui label two'
+                label: 'Ui label two'
             }
         };
 
@@ -465,32 +465,44 @@ describe('Metadata extractor', () => {
         const props = {
             devName: {
                 type: ElementPropTypes.string,
-                uiLabel: 'Ui label'
+                label: 'Ui label'
             },
             devNameTwo: {
                 type: ElementPropTypes.string,
-                uiLabel: 'Ui label two'
+                label: 'Ui label two'
             },
             devNameThree: ElementPropTypes.number,
             anIframe: {
                 type: ElementPropTypes.embeddable({
                     embedType: {
                         type: ElementPropTypes.string,
-                        uiLabel: 'My embed label'
+                        label: 'My embed label'
                     },
                     url: ElementPropTypes.string,
                     height: ElementPropTypes.number
                 }),
-                uiLabel: 'External Iframe'
+                label: 'External Iframe'
             },
             colors: {
                 type: ElementPropTypes.shape({
                     background: {
                         type: ElementPropTypes.color,
-                        uiLabel: 'My background color'
+                        label: 'My background color'
                     }
                 }),
-                uiLabel: 'My colors'
+                label: 'My colors'
+            },
+            anArray: {
+                type: ElementPropTypes.arrayOf(
+                    ElementPropTypes.shape({
+                        color: {
+                            type: ElementPropTypes.color,
+                            label: 'My Color'
+                        },
+                        oldProp: ElementPropTypes.string
+                    })
+                ),
+                label: 'Array of shape'
             }
         };
 
@@ -534,6 +546,23 @@ describe('Metadata extractor', () => {
                     'My background color': {
                         propName: 'background',
                         type: 'color'
+                    }
+                }
+            },
+            'Array of shape': {
+                propName: 'anArray',
+                type: 'arrayOf',
+                argType: {
+                    type: 'shape',
+                    objMeta: {
+                        'My Color': {
+                            propName: 'color',
+                            type: 'color'
+                        },
+                        'Old Prop': {
+                            propName: 'oldProp',
+                            type: 'string'
+                        }
                     }
                 }
             }

--- a/src/__tests__/extractMeta.js
+++ b/src/__tests__/extractMeta.js
@@ -568,4 +568,33 @@ describe('Metadata extractor', () => {
             }
         });
     });
+    it('Extracts aditional properties if provided', () => {
+        const props = {
+            devName: {
+                type: ElementPropTypes.string,
+                label: 'Ui label',
+                isAdvanced: true,
+                tooltip: 'A tooltip'
+            },
+            devNameTwo: {
+                type: ElementPropTypes.string,
+                label: 'Ui label two'
+            }
+        };
+
+        const extracted = extractMetadata(props);
+
+        expect(extracted).toEqual({
+            'Ui label': {
+                propName: 'devName',
+                type: 'string',
+                isAdvanced: true,
+                tooltip: 'A tooltip'
+            },
+            'Ui label two': {
+                propName: 'devNameTwo',
+                type: 'string'
+            }
+        });
+    });
 });

--- a/src/__tests__/extractMeta.js
+++ b/src/__tests__/extractMeta.js
@@ -434,4 +434,109 @@ describe('Metadata extractor', () => {
             type: 'readOnly'
         });
     });
+
+    it('Extracts metadata using provided ui label', () => {
+        const props = {
+            devName: {
+                type: ElementPropTypes.string,
+                uiLabel: 'Ui label'
+            },
+            devNameTwo: {
+                type: ElementPropTypes.string,
+                uiLabel: 'Ui label two'
+            }
+        };
+
+        const extracted = extractMetadata(props);
+
+        expect(extracted).toEqual({
+            'Ui label': {
+                propName: 'devName',
+                type: 'string'
+            },
+            'Ui label two': {
+                propName: 'devNameTwo',
+                type: 'string'
+            }
+        });
+    });
+
+    it('Extracts metadata using provided ui label - mixed with non label', () => {
+        const props = {
+            devName: {
+                type: ElementPropTypes.string,
+                uiLabel: 'Ui label'
+            },
+            devNameTwo: {
+                type: ElementPropTypes.string,
+                uiLabel: 'Ui label two'
+            },
+            devNameThree: ElementPropTypes.number,
+            anIframe: {
+                type: ElementPropTypes.embeddable({
+                    embedType: {
+                        type: ElementPropTypes.string,
+                        uiLabel: 'My embed label'
+                    },
+                    url: ElementPropTypes.string,
+                    height: ElementPropTypes.number
+                }),
+                uiLabel: 'External Iframe'
+            },
+            colors: {
+                type: ElementPropTypes.shape({
+                    background: {
+                        type: ElementPropTypes.color,
+                        uiLabel: 'My background color'
+                    }
+                }),
+                uiLabel: 'My colors'
+            }
+        };
+
+        const extracted = extractMetadata(props);
+
+        expect(extracted).toEqual({
+            'Ui label': {
+                propName: 'devName',
+                type: 'string'
+            },
+            'Ui label two': {
+                propName: 'devNameTwo',
+                type: 'string'
+            },
+            'Dev Name Three': {
+                propName: 'devNameThree',
+                type: 'number'
+            },
+            'External Iframe': {
+                propName: 'anIframe',
+                type: 'embeddable',
+                objMeta: {
+                    'My embed label': {
+                        propName: 'embedType',
+                        type: 'string'
+                    },
+                    Url: {
+                        propName: 'url',
+                        type: 'string'
+                    },
+                    Height: {
+                        propName: 'height',
+                        type: 'number'
+                    }
+                }
+            },
+            'My colors': {
+                propName: 'colors',
+                type: 'shape',
+                objMeta: {
+                    'My background color': {
+                        propName: 'background',
+                        type: 'color'
+                    }
+                }
+            }
+        });
+    });
 });

--- a/src/extractMeta.js
+++ b/src/extractMeta.js
@@ -10,7 +10,9 @@ const extractMetadata = props => {
         const propType = props[key].type ? props[key].type : props[key];
         extraction[label] = {
             ...propType._meta,
-            propName: key
+            propName: key,
+            isAdvanced: props[key].isAdvanced,
+            tooltip: props[key].tooltip
         };
     });
     return extraction;

--- a/src/extractMeta.js
+++ b/src/extractMeta.js
@@ -1,11 +1,15 @@
+/* eslint-disable security/detect-object-injection */
 import { fromCamelToSentence } from './utils';
 
 const extractMetadata = props => {
     const extraction = {};
     Object.keys(props).forEach(key => {
         const name = fromCamelToSentence(key);
-        extraction[name] = {
-            ...props[key]._meta,
+        const uiLabel = props[key].uiLabel;
+        const label = uiLabel ? uiLabel : name;
+        const propType = props[key].type ? props[key].type : props[key];
+        extraction[label] = {
+            ...propType._meta,
             propName: key
         };
     });

--- a/src/extractMeta.js
+++ b/src/extractMeta.js
@@ -5,7 +5,7 @@ const extractMetadata = props => {
     const extraction = {};
     Object.keys(props).forEach(key => {
         const name = fromCamelToSentence(key);
-        const uiLabel = props[key].uiLabel;
+        const uiLabel = props[key].label;
         const label = uiLabel ? uiLabel : name;
         const propType = props[key].type ? props[key].type : props[key];
         extraction[label] = {

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,4 +1,5 @@
 import { fromCamelToSentence } from './utils';
+import extractMetadata from './extractMeta';
 
 const PropTypes = {};
 
@@ -87,13 +88,7 @@ const createEnumTypeChecker = expectedValues => {
 
 const createShapeTypeChecker = type => shapeObj => {
     const appliedChecker = PropTypes.shape(shapeObj);
-    const objMeta = {};
-    Object.keys(shapeObj).forEach(key => {
-        objMeta[fromCamelToSentence(key)] = {
-            ...shapeObj[key]._meta,
-            propName: key
-        };
-    });
+    const objMeta = extractMetadata(shapeObj);
 
     appliedChecker._meta = {
         type,


### PR DESCRIPTION
Devs will be able to create the config schema like this:

```js
const props = {
            devName: {
                type: ElementPropTypes.string,
                uiLabel: 'Ui label'
            },
            devNameTwo: {
                type: ElementPropTypes.string,
                uiLabel: 'Ui label two'
            }
        };
```

A new `uiLabel` can be specified. 

This change is fully compatible with all blocks, meaning that we don't need to update existing blocks. A block config can be updated on demand to this flexible way of specifying the label.

No change is needed in the SD.