### PR TITLE
V2-3074 updated isPrivate and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ let props = {
 
   // Or a required one
   requiredEnum: ElementPropTypes.oneOf(['News', 'Photos']).isRequired,
+  
+  // Or a private one
+  requiredEnum: ElementPropTypes.oneOf(['News', 'Photos']).isPrivate,
 
   // An array of a certain type
   optionalArrayOf: ElementPropTypes.arrayOf(PropTypes.number),
@@ -546,6 +549,17 @@ The `labelPrefix` and `labelSuffix` props can be used to specify a string value 
 The `labelStepSize` prop allows you to control label step size independently of slider step size. If `labelStepSize` is not set, the `stepSize` value will be used.
 
 The `vertical` prop allows you to orient the slider in a vertical direction rather than the default of horizontal.
+
+### Modifying with .isPrivate
+
+The `.isPrivate` modifier can be applied similarly to `.isRequired` and has the effect of hiding the prop in Site Designer, except to agencies/organizations.
+
+For example:
+```js
+configSpec = {
+    myPrivateString: ElementPropTypes.string.isPrivate
+}
+```
 
 
 ### Versioning

--- a/src/__tests__/extractMeta.js
+++ b/src/__tests__/extractMeta.js
@@ -632,7 +632,7 @@ describe('Metadata extractor', () => {
     it('Extracts isPrivate metadata from string prop', () => {
         const props = {
             textProp: ElementPropTypes.string,
-            textPropRequired: ElementPropTypes.string.isPrivate
+            textPropPrivate: ElementPropTypes.string.isPrivate
         };
 
         const extracted = extractMetadata(props);
@@ -642,8 +642,8 @@ describe('Metadata extractor', () => {
             type: 'string'
         });
 
-        expect(extracted['Text Prop Required']).toEqual({
-            propName: 'textPropRequired',
+        expect(extracted['Text Prop Private']).toEqual({
+            propName: 'textPropPrivate',
             type: 'string',
             isPrivate: true
         });

--- a/src/__tests__/extractMeta.js
+++ b/src/__tests__/extractMeta.js
@@ -606,7 +606,6 @@ describe('Metadata extractor', () => {
             devName: {
                 type: ElementPropTypes.string,
                 label: 'Ui label',
-                isPrivate: true,
                 tooltip: 'A tooltip'
             },
             devNameTwo: {
@@ -621,13 +620,32 @@ describe('Metadata extractor', () => {
             'Ui label': {
                 propName: 'devName',
                 type: 'string',
-                isPrivate: true,
                 tooltip: 'A tooltip'
             },
             'Ui label two': {
                 propName: 'devNameTwo',
                 type: 'string'
             }
+        });
+    });
+
+    it('Extracts isPrivate metadata from string prop', () => {
+        const props = {
+            textProp: ElementPropTypes.string,
+            textPropRequired: ElementPropTypes.string.isPrivate
+        };
+
+        const extracted = extractMetadata(props);
+
+        expect(extracted['Text Prop']).toEqual({
+            propName: 'textProp',
+            type: 'string'
+        });
+
+        expect(extracted['Text Prop Required']).toEqual({
+            propName: 'textPropRequired',
+            type: 'string',
+            isPrivate: true
         });
     });
 });

--- a/src/extractMeta.js
+++ b/src/extractMeta.js
@@ -14,7 +14,6 @@ const extractMetadata = props => {
         extraction[label] = {
             ...propType._meta,
             propName: key,
-            isPrivate: props[key].isPrivate,
             tooltip: props[key].tooltip
         };
     });

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -6,7 +6,9 @@ const PropTypes = {};
 function getShim() {
     function shim() {}
     function requiredShim() {}
+    function privateShim() {}
     shim.isRequired = requiredShim;
+    shim.isPrivate = privateShim;
     return shim;
 }
 
@@ -53,6 +55,7 @@ const primitiveProp = type => {
     const checker = PropTypes[type];
     checker._meta = { type };
     checker.isRequired._meta = { type, isRequired: true };
+    checker.isPrivate._meta = { type, isPrivate: true };
     if (defaults[type]) {
         checker.default = defaults[type];
     }
@@ -70,6 +73,10 @@ const createTypeOfTypeChecker = type => arrType => {
         ...appliedChecker._meta,
         isRequired: true
     };
+    appliedChecker.isPrivate._meta = {
+        ...appliedChecker._meta,
+        isPrivate: true
+    };
     return appliedChecker;
 };
 
@@ -82,6 +89,10 @@ const createEnumTypeChecker = expectedValues => {
     appliedChecker.isRequired._meta = {
         ...appliedChecker._meta,
         isRequired: true
+    };
+    appliedChecker.isPrivate._meta = {
+        ...appliedChecker._meta,
+        isPrivate: true
     };
     return appliedChecker;
 };
@@ -97,6 +108,10 @@ const createShapeTypeChecker = type => shapeObj => {
     appliedChecker.isRequired._meta = {
         ...appliedChecker._meta,
         isRequired: true
+    };
+    appliedChecker.isPrivate._meta = {
+        ...appliedChecker._meta,
+        isPrivate: true
     };
     return appliedChecker;
 };


### PR DESCRIPTION
Updated code to handle setting `isPrivate` as a modifier for an element propType.

Addresses https://github.com/volusion/element-proptypes/issues/10