### PR TITLE
V2-2651 explicitly include label in extractMetadata output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-proptypes",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Wrapper around React PropTypes for adding metadata to the props",
   "author": "Volusion LLC",
   "license": "MIT",

--- a/src/__tests__/extractMeta.js
+++ b/src/__tests__/extractMeta.js
@@ -451,10 +451,12 @@ describe('Metadata extractor', () => {
 
         expect(extracted).toEqual({
             'Ui label': {
+                label: 'Ui label',
                 propName: 'devName',
                 type: 'string'
             },
             'Ui label two': {
+                label: 'Ui label two',
                 propName: 'devNameTwo',
                 type: 'string'
             }
@@ -510,10 +512,12 @@ describe('Metadata extractor', () => {
 
         expect(extracted).toEqual({
             'Ui label': {
+                label: 'Ui label',
                 propName: 'devName',
                 type: 'string'
             },
             'Ui label two': {
+                label: 'Ui label two',
                 propName: 'devNameTwo',
                 type: 'string'
             },
@@ -522,10 +526,12 @@ describe('Metadata extractor', () => {
                 type: 'number'
             },
             'External Iframe': {
+                label: 'External Iframe',
                 propName: 'anIframe',
                 type: 'embeddable',
                 objMeta: {
                     'My embed label': {
+                        label: 'My embed label',
                         propName: 'embedType',
                         type: 'string'
                     },
@@ -540,22 +546,26 @@ describe('Metadata extractor', () => {
                 }
             },
             'My colors': {
+                label: 'My colors',
                 propName: 'colors',
                 type: 'shape',
                 objMeta: {
                     'My background color': {
+                        label: 'My background color',
                         propName: 'background',
                         type: 'color'
                     }
                 }
             },
             'Array of shape': {
+                label: 'Array of shape',
                 propName: 'anArray',
                 type: 'arrayOf',
                 argType: {
                     type: 'shape',
                     objMeta: {
                         'My Color': {
+                            label: 'My Color',
                             propName: 'color',
                             type: 'color'
                         },
@@ -589,10 +599,12 @@ describe('Metadata extractor', () => {
 
         expect(extracted).toEqual({
             'My colors': {
+                label: 'My colors',
                 propName: 'colors',
                 type: 'shape',
                 objMeta: {
                     'My background color': {
+                        label: 'My background color',
                         propName: 'background',
                         type: 'color'
                     }
@@ -619,12 +631,14 @@ describe('Metadata extractor', () => {
 
         expect(extracted).toEqual({
             'Ui label': {
+                label: 'Ui label',
                 propName: 'devName',
                 type: 'string',
                 isPrivate: true,
                 tooltip: 'A tooltip'
             },
             'Ui label two': {
+                label: 'Ui label two',
                 propName: 'devNameTwo',
                 type: 'string'
             }

--- a/src/__tests__/extractMeta.js
+++ b/src/__tests__/extractMeta.js
@@ -463,6 +463,43 @@ describe('Metadata extractor', () => {
         });
     });
 
+    it('Extracts metadata using provided ui label and keeps the label even if it is falsey', () => {
+        const props = {
+            devName: {
+                type: ElementPropTypes.string,
+                label: ''
+            },
+            devNameTwo: {
+                type: ElementPropTypes.string,
+                label: false
+            },
+            devNameThree: {
+                type: ElementPropTypes.string,
+                label: null
+            }
+        };
+
+        const extracted = extractMetadata(props);
+
+        expect(extracted).toEqual({
+            'Dev Name': {
+                label: '',
+                propName: 'devName',
+                type: 'string'
+            },
+            'Dev Name Two': {
+                label: false,
+                propName: 'devNameTwo',
+                type: 'string'
+            },
+            'Dev Name Three': {
+                label: null,
+                propName: 'devNameThree',
+                type: 'string'
+            }
+        });
+    });
+
     it('Extracts metadata using provided ui label - mixed with non label', () => {
         const props = {
             devName: {

--- a/src/extractMeta.js
+++ b/src/extractMeta.js
@@ -13,6 +13,7 @@ const extractMetadata = props => {
         const propType = props[key].type ? props[key].type : props[key];
         extraction[label] = {
             ...propType._meta,
+            label: uiLabel,
             propName: key,
             isPrivate: props[key].isPrivate,
             tooltip: props[key].tooltip


### PR DESCRIPTION
This change keeps the original label value and stores it as the `label` prop in the metadata, so that it can be used downstream by Site Designer to make smarter decisions about how to handle label display.