### PR TITLE
V2-3588 use key (not label) to make keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -411,7 +411,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -431,7 +431,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
@@ -652,7 +652,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -1030,7 +1030,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
@@ -1839,7 +1839,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
@@ -2096,13 +2096,13 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -4192,7 +4192,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -4245,7 +4245,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -4367,7 +4367,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -4947,7 +4947,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -5378,7 +5378,7 @@
         },
         "callsites": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         },
@@ -5819,7 +5819,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -6499,7 +6499,7 @@
         },
         "inquirer": {
           "version": "5.2.0",
-          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
           "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "dev": true,
           "requires": {
@@ -6873,7 +6873,7 @@
       "dependencies": {
         "got": {
           "version": "6.7.1",
-          "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
@@ -7202,7 +7202,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -7913,7 +7913,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -7933,7 +7933,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
@@ -8113,7 +8113,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -9138,7 +9138,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -9219,7 +9219,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -9238,7 +9238,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -9310,7 +9310,7 @@
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volusion/element-proptypes",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Wrapper around React PropTypes for adding metadata to the props",
   "author": "Volusion LLC",
   "license": "MIT",

--- a/src/__tests__/extractMeta.js
+++ b/src/__tests__/extractMeta.js
@@ -10,12 +10,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Text Prop']).toEqual({
+        expect(extracted['textProp']).toEqual({
             propName: 'textProp',
             type: 'string'
         });
 
-        expect(extracted['Text Prop Required']).toEqual({
+        expect(extracted['textPropRequired']).toEqual({
             propName: 'textPropRequired',
             type: 'string',
             isRequired: true
@@ -30,12 +30,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Color Prop']).toEqual({
+        expect(extracted['colorProp']).toEqual({
             propName: 'colorProp',
             type: 'color'
         });
 
-        expect(extracted['Color Prop Required']).toEqual({
+        expect(extracted['colorPropRequired']).toEqual({
             propName: 'colorPropRequired',
             type: 'color',
             isRequired: true
@@ -50,12 +50,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Number Prop']).toEqual({
+        expect(extracted['numberProp']).toEqual({
             propName: 'numberProp',
             type: 'number'
         });
 
-        expect(extracted['Number Prop Required']).toEqual({
+        expect(extracted['numberPropRequired']).toEqual({
             propName: 'numberPropRequired',
             type: 'number',
             isRequired: true
@@ -70,12 +70,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Bool Prop']).toEqual({
+        expect(extracted['boolProp']).toEqual({
             propName: 'boolProp',
             type: 'bool'
         });
 
-        expect(extracted['Bool Prop Required']).toEqual({
+        expect(extracted['boolPropRequired']).toEqual({
             propName: 'boolPropRequired',
             type: 'bool',
             isRequired: true
@@ -90,12 +90,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Media Prop']).toEqual({
+        expect(extracted['mediaProp']).toEqual({
             propName: 'mediaProp',
             type: 'media'
         });
 
-        expect(extracted['Media Prop Required']).toEqual({
+        expect(extracted['mediaPropRequired']).toEqual({
             propName: 'mediaPropRequired',
             type: 'media',
             isRequired: true
@@ -110,12 +110,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Product Prop']).toEqual({
+        expect(extracted['productProp']).toEqual({
             propName: 'productProp',
             type: 'product'
         });
 
-        expect(extracted['Product Prop Required']).toEqual({
+        expect(extracted['productPropRequired']).toEqual({
             propName: 'productPropRequired',
             type: 'product',
             isRequired: true
@@ -130,12 +130,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Category Prop']).toEqual({
+        expect(extracted['categoryProp']).toEqual({
             propName: 'categoryProp',
             type: 'category'
         });
 
-        expect(extracted['Category Prop Required']).toEqual({
+        expect(extracted['categoryPropRequired']).toEqual({
             propName: 'categoryPropRequired',
             type: 'category',
             isRequired: true
@@ -150,12 +150,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Section Header Prop']).toEqual({
+        expect(extracted['sectionHeaderProp']).toEqual({
             propName: 'sectionHeaderProp',
             type: 'sectionHeader'
         });
 
-        expect(extracted['Section Header Prop Required']).toEqual({
+        expect(extracted['sectionHeaderPropRequired']).toEqual({
             propName: 'sectionHeaderPropRequired',
             type: 'sectionHeader',
             isRequired: true
@@ -170,12 +170,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Editor Full Prop']).toEqual({
+        expect(extracted['editorFullProp']).toEqual({
             propName: 'editorFullProp',
             type: 'editorFull'
         });
 
-        expect(extracted['Editor Full Prop Required']).toEqual({
+        expect(extracted['editorFullPropRequired']).toEqual({
             propName: 'editorFullPropRequired',
             type: 'editorFull',
             isRequired: true
@@ -190,12 +190,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Editor Minimal Prop']).toEqual({
+        expect(extracted['editorMinimalProp']).toEqual({
             propName: 'editorMinimalProp',
             type: 'editorMinimal'
         });
 
-        expect(extracted['Editor Minimal Prop Required']).toEqual({
+        expect(extracted['editorMinimalPropRequired']).toEqual({
             propName: 'editorMinimalPropRequired',
             type: 'editorMinimal',
             isRequired: true
@@ -212,7 +212,7 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Some Numbers']).toEqual({
+        expect(extracted['someNumbers']).toEqual({
             propName: 'someNumbers',
             type: 'arrayOf',
             argType: {
@@ -220,7 +220,7 @@ describe('Metadata extractor', () => {
             }
         });
 
-        expect(extracted['Some Numbers Required']).toEqual({
+        expect(extracted['someNumbersRequired']).toEqual({
             propName: 'someNumbersRequired',
             type: 'arrayOf',
             argType: {
@@ -239,7 +239,7 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['An Object']).toEqual({
+        expect(extracted['anObject']).toEqual({
             propName: 'anObject',
             type: 'objectOf',
             argType: {
@@ -247,7 +247,7 @@ describe('Metadata extractor', () => {
             }
         });
 
-        expect(extracted['An Object Required']).toEqual({
+        expect(extracted['anObjectRequired']).toEqual({
             propName: 'anObjectRequired',
             type: 'objectOf',
             argType: {
@@ -266,13 +266,13 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Some Options']).toEqual({
+        expect(extracted['someOptions']).toEqual({
             propName: 'someOptions',
             type: 'oneOf',
             values: ['bottom', 'top']
         });
 
-        expect(extracted['Some Options Required']).toEqual({
+        expect(extracted['someOptionsRequired']).toEqual({
             propName: 'someOptionsRequired',
             type: 'oneOf',
             values: ['bottom', 'top'],
@@ -294,30 +294,30 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['A Shape']).toEqual({
+        expect(extracted['aShape']).toEqual({
             propName: 'aShape',
             type: 'shape',
             objMeta: {
-                'A Tricky Prop': {
+                aTrickyProp: {
                     propName: 'aTrickyProp',
                     type: 'string'
                 },
-                'Not A Tricky Prop': {
+                notATrickyProp: {
                     propName: 'notATrickyProp',
                     type: 'number'
                 }
             }
         });
 
-        expect(extracted['A Shape Required']).toEqual({
+        expect(extracted['aShapeRequired']).toEqual({
             propName: 'aShapeRequired',
             type: 'shape',
             objMeta: {
-                'A Tricky Prop': {
+                aTrickyProp: {
                     propName: 'aTrickyProp',
                     type: 'string'
                 },
-                'Not A Tricky Prop': {
+                notATrickyProp: {
                     propName: 'notATrickyProp',
                     type: 'number'
                 }
@@ -337,19 +337,19 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['An Iframe']).toEqual({
+        expect(extracted['anIframe']).toEqual({
             propName: 'anIframe',
             type: 'embeddable',
             objMeta: {
-                'Embed Type': {
+                embedType: {
                     propName: 'embedType',
                     type: 'string'
                 },
-                Url: {
+                url: {
                     propName: 'url',
                     type: 'string'
                 },
-                Height: {
+                height: {
                     propName: 'height',
                     type: 'number'
                 }
@@ -365,12 +365,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Image Prop']).toEqual({
+        expect(extracted['imageProp']).toEqual({
             propName: 'imageProp',
             type: 'image'
         });
 
-        expect(extracted['Image Prop Required']).toEqual({
+        expect(extracted['imagePropRequired']).toEqual({
             propName: 'imagePropRequired',
             type: 'image',
             isRequired: true
@@ -398,12 +398,12 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['Slider Prop']).toEqual({
+        expect(extracted['sliderProp']).toEqual({
             propName: 'sliderProp',
             type: 'slider'
         });
 
-        expect(extracted['Slider Prop Required']).toEqual({
+        expect(extracted['sliderPropRequired']).toEqual({
             propName: 'sliderPropRequired',
             type: 'slider',
             isRequired: true
@@ -429,7 +429,7 @@ describe('Metadata extractor', () => {
 
         const extracted = extractMetadata(props);
 
-        expect(extracted['A Read Only']).toEqual({
+        expect(extracted['aReadOnly']).toEqual({
             propName: 'aReadOnly',
             type: 'readOnly'
         });
@@ -450,12 +450,12 @@ describe('Metadata extractor', () => {
         const extracted = extractMetadata(props);
 
         expect(extracted).toEqual({
-            'Ui label': {
+            devName: {
                 label: 'Ui label',
                 propName: 'devName',
                 type: 'string'
             },
-            'Ui label two': {
+            devNameTwo: {
                 label: 'Ui label two',
                 propName: 'devNameTwo',
                 type: 'string'
@@ -482,17 +482,17 @@ describe('Metadata extractor', () => {
         const extracted = extractMetadata(props);
 
         expect(extracted).toEqual({
-            'Dev Name': {
+            devName: {
                 label: '',
                 propName: 'devName',
                 type: 'string'
             },
-            'Dev Name Two': {
+            devNameTwo: {
                 label: false,
                 propName: 'devNameTwo',
                 type: 'string'
             },
-            'Dev Name Three': {
+            devNameThree: {
                 label: null,
                 propName: 'devNameThree',
                 type: 'string'
@@ -548,65 +548,65 @@ describe('Metadata extractor', () => {
         const extracted = extractMetadata(props);
 
         expect(extracted).toEqual({
-            'Ui label': {
+            devName: {
                 label: 'Ui label',
                 propName: 'devName',
                 type: 'string'
             },
-            'Ui label two': {
+            devNameTwo: {
                 label: 'Ui label two',
                 propName: 'devNameTwo',
                 type: 'string'
             },
-            'Dev Name Three': {
+            devNameThree: {
                 propName: 'devNameThree',
                 type: 'number'
             },
-            'External Iframe': {
+            anIframe: {
                 label: 'External Iframe',
                 propName: 'anIframe',
                 type: 'embeddable',
                 objMeta: {
-                    'My embed label': {
+                    embedType: {
                         label: 'My embed label',
                         propName: 'embedType',
                         type: 'string'
                     },
-                    Url: {
+                    url: {
                         propName: 'url',
                         type: 'string'
                     },
-                    Height: {
+                    height: {
                         propName: 'height',
                         type: 'number'
                     }
                 }
             },
-            'My colors': {
+            colors: {
                 label: 'My colors',
                 propName: 'colors',
                 type: 'shape',
                 objMeta: {
-                    'My background color': {
+                    background: {
                         label: 'My background color',
                         propName: 'background',
                         type: 'color'
                     }
                 }
             },
-            'Array of shape': {
+            anArray: {
                 label: 'Array of shape',
                 propName: 'anArray',
                 type: 'arrayOf',
                 argType: {
                     type: 'shape',
                     objMeta: {
-                        'My Color': {
+                        color: {
                             label: 'My Color',
                             propName: 'color',
                             type: 'color'
                         },
-                        'Old Prop': {
+                        oldProp: {
                             propName: 'oldProp',
                             type: 'string'
                         }
@@ -635,12 +635,12 @@ describe('Metadata extractor', () => {
         const extracted = extractMetadata(props);
 
         expect(extracted).toEqual({
-            'My colors': {
+            colors: {
                 label: 'My colors',
                 propName: 'colors',
                 type: 'shape',
                 objMeta: {
-                    'My background color': {
+                    background: {
                         label: 'My background color',
                         propName: 'background',
                         type: 'color'
@@ -667,15 +667,43 @@ describe('Metadata extractor', () => {
         const extracted = extractMetadata(props);
 
         expect(extracted).toEqual({
-            'Ui label': {
+            devName: {
                 label: 'Ui label',
                 propName: 'devName',
                 type: 'string',
                 isPrivate: true,
                 tooltip: 'A tooltip'
             },
-            'Ui label two': {
+            devNameTwo: {
                 label: 'Ui label two',
+                propName: 'devNameTwo',
+                type: 'string'
+            }
+        });
+    });
+
+    it('Extracts metadata safely if labels are not unique', () => {
+        const props = {
+            devName: {
+                type: ElementPropTypes.string,
+                label: 'Ui label'
+            },
+            devNameTwo: {
+                type: ElementPropTypes.string,
+                label: 'Ui label'
+            }
+        };
+
+        const extracted = extractMetadata(props);
+
+        expect(extracted).toEqual({
+            devName: {
+                label: 'Ui label',
+                propName: 'devName',
+                type: 'string'
+            },
+            devNameTwo: {
+                label: 'Ui label',
                 propName: 'devNameTwo',
                 type: 'string'
             }

--- a/src/__tests__/extractMeta.js
+++ b/src/__tests__/extractMeta.js
@@ -709,4 +709,83 @@ describe('Metadata extractor', () => {
             }
         });
     });
+    it('Extracts metadata safely if nested keys are not unique', () => {
+        const props = {
+            arrayOne: {
+                label: 'Array label',
+                type: ElementPropTypes.arrayOf(
+                    ElementPropTypes.shape({
+                        keyOne: {
+                            label: 'Ui label one',
+                            type: ElementPropTypes.string
+                        },
+                        keyTwo: {
+                            label: 'Ui label two',
+                            type: ElementPropTypes.string
+                        }
+                    })
+                )
+            },
+            arrayTwo: {
+                label: 'Array label',
+                type: ElementPropTypes.arrayOf(
+                    ElementPropTypes.shape({
+                        keyOne: {
+                            label: 'Ui label one',
+                            type: ElementPropTypes.string
+                        },
+                        keyTwo: {
+                            label: 'Ui label two',
+                            type: ElementPropTypes.string
+                        }
+                    })
+                )
+            }
+        };
+       
+        const extracted = extractMetadata(props);
+
+        expect(extracted).toEqual({
+            arrayOne: {
+                argType: {
+                    objMeta: {
+                        keyOne: {
+                            label: 'Ui label one',
+                            propName: 'keyOne',
+                            type: 'string'
+                        },
+                        keyTwo: {
+                            label: 'Ui label two',
+                            propName: 'keyTwo',
+                            type: 'string'
+                        }
+                    },
+                    type: 'shape'
+                },
+                label: 'Array label',
+                propName: 'arrayOne',
+                type: 'arrayOf'
+            },
+            arrayTwo: {
+                argType: {
+                    objMeta: {
+                        keyOne: {
+                            label: 'Ui label one',
+                            propName: 'keyOne',
+                            type: 'string'
+                        },
+                        keyTwo: {
+                            label: 'Ui label two',
+                            propName: 'keyTwo',
+                            type: 'string'
+                        }
+                    },
+                    type: 'shape'
+                },
+                label: 'Array label',
+                propName: 'arrayTwo',
+                type: 'arrayOf'
+            }
+        });
+    });
 });

--- a/src/extractMeta.js
+++ b/src/extractMeta.js
@@ -1,5 +1,4 @@
 /* eslint-disable security/detect-object-injection */
-import { fromCamelToSentence } from './utils';
 
 const extractMetadata = props => {
     const extraction = {};
@@ -7,13 +6,10 @@ const extractMetadata = props => {
         if (!props[key]) {
             return;
         }
-        const name = fromCamelToSentence(key);
-        const uiLabel = props[key].label;
-        const label = uiLabel ? uiLabel : name;
         const propType = props[key].type ? props[key].type : props[key];
-        extraction[label] = {
+        extraction[key] = {
             ...propType._meta,
-            label: uiLabel,
+            label: props[key].label,
             propName: key,
             isPrivate: props[key].isPrivate,
             tooltip: props[key].tooltip

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,4 +1,4 @@
-import { fromCamelToSentence } from './utils';
+/* eslint-disable security/detect-object-injection */
 import extractMetadata from './extractMeta';
 
 const PropTypes = {};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,0 @@
-const capitalize = string => {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-};
-
-const fromCamelToSentence = camelCaseString => {
-    return capitalize(camelCaseString.split(/(?=[A-Z])/).join(' '));
-};
-
-export { fromCamelToSentence };


### PR DESCRIPTION
These changes add support for non-unique labels by changing the way that `extraction` object keys are set, using key, rather than label.

Before these changes, using non-unique label values at the same depth of a config would cause object keys to be overwritten and the `extractMetadata` output to be wrong.

Unit tests have been updated.

We also no longer need the `fromCamelToSentence` util, so it has been removed.