### PR TITLE
feat: NP-1441 Element: Create an Icon Proptype

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ let props = {
   optionalCategory: ElementPropTypes.category,
   optionalCategory: ElementPropTypes.sectionHeader,
   optionalCategory: ElementPropTypes.subHeader,
+  optionalIcon: ElementPropTypes.icon,
   optionalImage: ElementPropTypes.image,
   optionalSlider: ElementPropTypes.slider,
   optionalMedia: ElementPropTypes.media,
@@ -47,6 +48,7 @@ let props = {
   requiredCategory: ElementPropTypes.category,
   requiredCategory: ElementPropTypes.sectionHeader,
   requiredCategory: ElementPropTypes.subHeader,
+  requiredIcon: ElementPropTypes.icon,
   requiredImage: ElementPropTypes.image,
   requiredSlider: ElementPropTypes.slider,
   requiredMedia: ElementPropTypes.media,
@@ -249,6 +251,39 @@ const meta = extractMetadata(props);
         type: 'number'
       }
     },
+    isRequired: true
+  },
+  'Optional Icon': {
+    objMeta: {
+        'Icon Name': {
+            propName: 'iconName',
+            type: 'string'
+        },
+        'Icon Prefix': {
+            propName: 'iconPrefix',
+            type: 'string'
+        },
+        'Default Filter': {
+            propName: 'defaultFilter',
+            type: 'string'
+        },
+    }
+  },
+  'Required Image': {
+    objMeta: {
+        'Icon Name': {
+            propName: 'iconName',
+            type: 'string'
+        },
+        'Icon Prefix': {
+            propName: 'iconPrefix',
+            type: 'string'
+        },
+        'Default Filter': {
+            propName: 'defaultFilter',
+            type: 'string'
+        },
+    }
     isRequired: true
   },
   'Optional Image': {
@@ -495,6 +530,37 @@ defaultProps = {
 
 `url` is the site you want to load in the embedded iframe, and `height` is the number representing the height of
 the iframe.
+
+### Using the icon proptype
+
+The `icon` propType will launch an icon picker in Site Designer when editing the block config.
+
+Site Designer will populate the `icon` like this when an icon has been selected:
+
+```
+iconConfig: {
+    iconName: 'cart-shopping',
+    iconPrefix: 'fa',
+    defaultFilter: 'shopping',
+}
+```
+
+You can use `ElementPropTypes.icon.default` in your default props, which will return this:
+
+```
+{
+    iconName: '',
+    iconPrefix: '',
+    defaultFilter: '',
+}
+```
+
+And it would be used in default props like this:
+```
+defaultProps = {
+    iconConfig: ElementPropTypes.icon.default
+}
+```
 
 ### Using the image proptype
 

--- a/src/__tests__/extractMeta.ts
+++ b/src/__tests__/extractMeta.ts
@@ -397,6 +397,18 @@ describe('Metadata extractor', () => {
         });
     });
 
+
+    it('Returns a default config for the icon type', () => {
+        const props = {
+            iconProp: ElementPropTypes.icon
+        };
+        expect(props.iconProp.default).toEqual({
+            defaultFilter: '',
+            iconName: '',
+            iconPrefix: ''
+        });
+    });
+
     it('Extracts metadata from shape prop', () => {
         const props = {
             aShape: ElementPropTypes.shape({

--- a/src/propTypes.ts
+++ b/src/propTypes.ts
@@ -16,6 +16,7 @@ function getShim() {
     'string',
     'color',
     'number',
+    'icon',
     'image',
     'slider',
     'media',
@@ -40,6 +41,11 @@ function getShim() {
 );
 
 const defaults = {
+    icon: {
+        iconName: '',
+        iconPrefix: '',
+        defaultFilter: '',
+    },
     image: {
         uriBase: '',
         imagePath: '',


### PR DESCRIPTION
https://volusion.atlassian.net/browse/NP-1441

Turns out this is building upon a previous PR from when this project was originally started a couple years ago: https://github.com/volusion/element-proptypes/pull/30

## Solution

- add the default shape of an icon proptype which includes,
  - the name of the icon
  - the prefix (which library it comes from) needed to render an individual FontAwesome Icon when you're not just loading them all
  - a filter so that the block developer can specify which icon search (by name or tag), we should show by default 